### PR TITLE
add new Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,31 +1,29 @@
-#!/usr/bin/env groovy
-import hudson.model.*
-
-timeout(time: 120, unit: 'MINUTES') {
-    node('master') {
-
-        try {
-
-            // Clean up work space
-            step([$class: 'WsCleanup'])
-
-            checkout changelog: false, poll: false, scm: [
-                    $class: 'GitSCM',
-                    branches: [[name: '*/master']],
-                    extensions: [[$class: 'SparseCheckoutPaths', sparseCheckoutPaths: [[path: 'jenkins/jenkins-pipeline/Jenkinsfile_master']]]],
-                    userRemoteConfigs: [[credentialsId: 'av-jenkins-reader', url: "https://github.com/AnyVisionltd/devops.git"]]
-            ]
-
-            //load remote jenkins_pipeline
-            def generic_pipeline = load "jenkins/jenkins-pipeline/Jenkinsfile_master"
-            //start remote jenkins_pipeline
-            generic_pipeline.generic_pipeline_method()
-
-        } //end catch
-        catch(err){
-
-            throw err
-            exit 1
-        } //end catch
-    } // end of node
-} //end of timeout
+pipeline {
+    agent { 
+        label 'cicd'
+    }
+    options {
+        timestamps()
+        disableConcurrentBuilds()
+        ansiColor('xterm')
+        timeout(time: 3, unit: 'HOURS')
+        buildDiscarder(logRotator(numToKeepStr:'50'))        
+    }    
+    libraries {
+        lib('pipeline-library')
+    }
+    environment {
+        SHORT_COMMIT = "${GIT_COMMIT[0..6]}"
+        SKIP_HELM = 'true'
+        SERVICE_NAME = 'coturn'
+    }
+    stages {
+        stage('Initialize') {     
+            steps {
+                script {
+                    genericPipelineGeneral()
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION

In order to migrate all of our CI build flows from codefresh into the new jenkins, we need to add this Jenkinsfile that will trigger build ci in the new jenkins

this commit will prepare migrate the automation-proxy docker image build from code fresh into new jenkins